### PR TITLE
Fix lingering mouse pointer after unpause

### DIFF
--- a/menumanager.lua
+++ b/menumanager.lua
@@ -391,7 +391,7 @@ function RadialMouseMenu:Hide(skip_reset,do_success_cb)
 			player:movement():current_state()._menu_closed_fire_cooldown = player:movement():current_state()._menu_closed_fire_cooldown + 0.01
 		end
 		self:on_closed()
-		managers.mouse_pointer:_deactivate(RadialMouseMenu.MOUSE_ID)
+		managers.mouse_pointer:remove_mouse(RadialMouseMenu.MOUSE_ID)
 		if do_success_cb then 
 			if item then 
 				self:on_item_clicked(item,true) --already hiding here so skip_hide 


### PR DESCRIPTION
I was having a bug where after unpausing, the mouse cursor would stick around and be able to interact with an invisible radial menu. I was able to track it down to MousePointerManager:_deactivate being called instead of MousePointerManager:remove_mouse